### PR TITLE
Improve the exceptions that are thrown by Kotlin-Guiced

### DIFF
--- a/core/src/main/kotlin/org/jlleitschuh/guice/Module.kt
+++ b/core/src/main/kotlin/org/jlleitschuh/guice/Module.kt
@@ -1,14 +1,18 @@
 package org.jlleitschuh.guice
 
+import com.google.inject.Binder
 import com.google.inject.Module
 import com.google.inject.PrivateModule
+import com.google.inject.binder.AnnotatedBindingBuilder
+import org.jlleitschuh.guice.binder.LinkedBindingBuilderScope
+import org.jlleitschuh.guice.binder.ScopedBindingBuilderScope
 
 /**
  * Creates a [Module] with the [BinderScope] being configured when [Module.configure]
  * is called by Guice.
  */
 fun module(configure: BinderScope.() -> Unit) =
-    Module { binder -> BinderScope(binder).configure() }
+    Module { binder -> BinderScope(binder.excludesLibrarySources()).configure() }
 
 /**
  * Creates a [PrivateModule] with the [PrivateBinderScope] being configured when [PrivateModule.configure]
@@ -18,6 +22,14 @@ fun privateModule(configure: PrivateBinderScope.() -> Unit) =
     // The PrivateModule data type has some reflection checks to get the right type passed in. Easier to just use it.
     object : PrivateModule() {
         override fun configure() =
-            configure.invoke(PrivateBinderScope(binder()))
-
+            configure.invoke(PrivateBinderScope(binder().excludesLibrarySources()))
     }
+
+private inline fun <reified T : Binder> T.excludesLibrarySources(): T =
+    skipSources(
+        BinderScope::class.java,
+        PrivateBinderScope::class.java,
+        AnnotatedBindingBuilder::class.java,
+        LinkedBindingBuilderScope::class.java,
+        ScopedBindingBuilderScope::class.java
+    ) as T

--- a/core/src/test/kotlin/org/jlleitschuh/guice/ModuleTest.kt
+++ b/core/src/test/kotlin/org/jlleitschuh/guice/ModuleTest.kt
@@ -1,11 +1,16 @@
 package org.jlleitschuh.guice
 
 import com.google.inject.AbstractModule
+import com.google.inject.CreationException
 import com.google.inject.Guice
+import com.natpryce.hamkrest.and
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ModuleTest {
 
@@ -71,5 +76,23 @@ class ModuleTest {
         val first = injector.getInstance(key<Interface>())
         val second = injector.getInstance(key<Interface>())
         assertNotSame(first, second)
+    }
+
+    @Test
+    fun `module binding exceptions provide meaningful exceptions`() {
+        val module = module {
+            bind<Interface>().toProvider<InterfaceProvider>()
+            bind<Interface>().toProvider<InterfaceProvider2>()
+        }
+        val exception = assertThrows<CreationException> {
+            Guice.createInjector(module)
+        }
+
+        val expectedString1 =
+            "1) A binding to org.jlleitschuh.guice.Interface was already configured at org.jlleitschuh.guice.ModuleTest${'$'}module binding exceptions provide meaningful exceptions${'$'}module${'$'}1.invoke(ModuleTest.kt:"
+        val expectedString2 =
+            "at org.jlleitschuh.guice.ModuleTest${'$'}module binding exceptions provide meaningful exceptions${'$'}module${'$'}1.invoke(ModuleTest.kt:"
+
+        assertThat(exception.message!!, containsSubstring(expectedString1) and containsSubstring(expectedString2))
     }
 }

--- a/core/src/test/kotlin/org/jlleitschuh/guice/TestUtility.kt
+++ b/core/src/test/kotlin/org/jlleitschuh/guice/TestUtility.kt
@@ -9,3 +9,7 @@ class Implementation : Interface
 class InterfaceProvider : Provider<Interface> {
     override fun get() = Implementation()
 }
+
+class InterfaceProvider2 : Provider<Interface> {
+    override fun get() = Implementation()
+}

--- a/kotlin-guiced.gradle.kts
+++ b/kotlin-guiced.gradle.kts
@@ -3,6 +3,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.wrapper.Wrapper
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
     repositories {
@@ -69,8 +70,24 @@ subprojects {
 
         "testCompile"(junitJupiter("junit-jupiter-api"))
         "testCompile"(junitJupiter("junit-jupiter-params"))
+        "testCompile"(group = "com.natpryce", name = "hamkrest", version = "1.5.0.0")
         "testRuntime"(junitJupiter("junit-jupiter-engine"))
         "testRuntime"(create(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.3.1"))
+    }
+
+    tasks.withType<KotlinCompile>().configureEach {
+        // Kotlin incremental compilation is enabled by default
+        kotlinOptions {
+            jvmTarget = "1.8"
+
+            freeCompilerArgs += "-Xprogressive"
+
+            /*
+             * Enables strict null checking when calling java methods using jsr305 annotations.
+             * https://kotlinlang.org/docs/reference/java-interop.html#jsr-305-support
+             */
+            freeCompilerArgs += "-Xjsr305=strict"
+        }
     }
 
     tasks.withType<Test>().configureEach {

--- a/kotlin-guiced.gradle.kts
+++ b/kotlin-guiced.gradle.kts
@@ -80,8 +80,7 @@ subprojects {
         kotlinOptions {
             jvmTarget = "1.8"
 
-            // https://kotlinlang.org/docs/reference/whatsnew13.html#progressive-mode
-            freeCompilerArgs += "-progressive"
+            freeCompilerArgs += "-Xprogressive"
 
             /*
              * Enables strict null checking when calling java methods using jsr305 annotations.

--- a/kotlin-guiced.gradle.kts
+++ b/kotlin-guiced.gradle.kts
@@ -80,7 +80,8 @@ subprojects {
         kotlinOptions {
             jvmTarget = "1.8"
 
-            freeCompilerArgs += "-Xprogressive"
+            // https://kotlinlang.org/docs/reference/whatsnew13.html#progressive-mode
+            freeCompilerArgs += "-progressive"
 
             /*
              * Enables strict null checking when calling java methods using jsr305 annotations.


### PR DESCRIPTION
Before:
```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) A binding to org.jlleitschuh.guice.Interface was already configured at org.jlleitschuh.guice.BinderScope.bind(BinderScope.kt:43).
  at org.jlleitschuh.guice.BinderScope.bind(BinderScope.kt:43)

```
Now:
```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) A binding to org.jlleitschuh.guice.Interface was already configured at org.jlleitschuh.guice.ModuleTest$module binding exceptions provide meaningful exceptions$module$1.invoke(ModuleTest.kt:100).
  at org.jlleitschuh.guice.ModuleTest$module binding exceptions provide meaningful exceptions$module$1.invoke(ModuleTest.kt:104)
```

